### PR TITLE
Fixes #2: Include slice offset when updating buffer capacity from current Bytes size

### DIFF
--- a/buffer/src/main/java/io/atomix/catalyst/buffer/AbstractBuffer.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/AbstractBuffer.java
@@ -363,7 +363,7 @@ public abstract class AbstractBuffer implements Buffer {
       if (offset + length > capacity) {
         if (capacity < maxCapacity) {
           if (this.offset + offset + length <= bytes.size()) {
-            capacity = bytes.size();
+            capacity = bytes.size() - this.offset;
           } else {
             capacity(calculateCapacity(offset + length));
           }

--- a/buffer/src/test/java/io/atomix/catalyst/buffer/FileBufferTest.java
+++ b/buffer/src/test/java/io/atomix/catalyst/buffer/FileBufferTest.java
@@ -15,14 +15,12 @@
  */
 package io.atomix.catalyst.buffer;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import org.testng.annotations.AfterTest;
 
 import java.io.File;
 import java.nio.file.Files;
 
-import org.testng.annotations.AfterTest;
+import static org.testng.Assert.*;
 
 /**
  * File buffer test.


### PR DESCRIPTION
This is the fix for #2. I'm having trouble writing tests for `Buffer` that reproduce the issue prior to the fix simply because it's such a specific case. `Buffer` and `Bytes` scale differently from each other since `Buffer` can be relative to its `offset` (for slices) and `Bytes` are fixed and so scale by powers of `2`. In order to reproduce this bug, those two scales must line up precisely so that the `Buffer` uses the underlying `Bytes` size but doesn't take its offset into account, thus assuming the underlying `Bytes` capacity is greater than it is in later bounds checks:

https://github.com/atomix/catalyst/blob/master/buffer/src/main/java/io/atomix/catalyst/buffer/AbstractBuffer.java#L366

I've verified that this fixes the bugs I've been able to reproduce in [Copycat](http://github.com/atomix/copycat). @madjam can you verify the same?
