### PR TITLE
Fix Netty ByteBuf leak

### DIFF
--- a/netty/src/main/java/io/atomix/catalyst/transport/NettyConnection.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/NettyConnection.java
@@ -91,6 +91,7 @@ public class NettyConnection implements Connection {
     } else {
       handleRequestFailure(requestId, new IllegalStateException("unknown message type: " + request.getClass()));
     }
+    buffer.release();
   }
 
   /**


### PR DESCRIPTION
Turning on advanced leak detection surfaced this one place where we might not be releasing bytebuf instances.
