### PR TITLE
Extract enclosing class for enums containing methods

### DIFF
--- a/serializer/src/main/java/io/atomix/catalyst/serializer/Serializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/Serializer.java
@@ -558,6 +558,11 @@ public class Serializer implements Cloneable {
 
     Class<?> type = object.getClass();
 
+    // Enums that implement interfaces or methods are generated as inner classes. For this reason,
+    // we need to get the enclosing class if it's an enum.
+    if (type.getEnclosingClass() != null && type.getEnclosingClass().isEnum())
+      type = type.getEnclosingClass();
+
     Integer typeId = registry.ids().get(type);
     if (typeId != null) {
       TypeSerializer<?> serializer = getSerializer(type);

--- a/serializer/src/test/java/io/atomix/catalyst/serializer/SerializerTest.java
+++ b/serializer/src/test/java/io/atomix/catalyst/serializer/SerializerTest.java
@@ -300,6 +300,17 @@ public class SerializerTest {
   }
 
   /**
+   * Tests serializing an enum.
+   */
+  public void testSerializeEnumInterface() {
+    Serializer serializer = new Serializer();
+    TestEnumInterface test = TestEnumImplements.THREE;
+    Buffer buffer = serializer.writeObject(test).flip();
+    Enum<?> result = serializer.readObject(buffer);
+    assertEquals(test, result);
+  }
+
+  /**
    * Tests serializing a list.
    */
   public void testSerializeList() {
@@ -604,6 +615,30 @@ public class SerializerTest {
     ONE,
     TWO,
     THREE
+  }
+
+  public interface TestEnumInterface {
+    void test();
+  }
+
+  public enum TestEnumImplements implements TestEnumInterface {
+    ONE {
+      @Override
+      public void test() {
+      }
+    },
+    TWO {
+      @Override
+      public void test() {
+
+      }
+    },
+    THREE {
+      @Override
+      public void test() {
+
+      }
+    }
   }
 
 }


### PR DESCRIPTION
This PR fixes a bug when serializing enums that implement interfaces with methods or simply add methods. When methods are present, enum values are generated as inner classes to the parent enum. This PR fixes this issue by grabbing the outer enum class during serialization.
