### PR TITLE
Initialize direct unsafe buffers to 0

### DIFF
--- a/buffer/src/main/java/io/atomix/catalyst/buffer/util/DirectMemoryAllocator.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/util/DirectMemoryAllocator.java
@@ -31,7 +31,11 @@ public class DirectMemoryAllocator implements MemoryAllocator<NativeMemory> {
 
   @Override
   public DirectMemory reallocate(NativeMemory memory, long size) {
-    return new DirectMemory(DirectMemory.UNSAFE.reallocateMemory(memory.address(), size), size, this);
+    DirectMemory newMemory = new DirectMemory(DirectMemory.UNSAFE.reallocateMemory(memory.address(), size), size, this);
+    if (newMemory.size() > memory.size()) {
+      DirectMemory.UNSAFE.setMemory(newMemory.address(), newMemory.size() - memory.size(), (byte) 0);
+    }
+    return newMemory;
   }
 
 }

--- a/buffer/src/main/java/io/atomix/catalyst/buffer/util/DirectMemoryAllocator.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/util/DirectMemoryAllocator.java
@@ -24,7 +24,9 @@ public class DirectMemoryAllocator implements MemoryAllocator<NativeMemory> {
 
   @Override
   public DirectMemory allocate(long size) {
-    return new DirectMemory(DirectMemory.UNSAFE.allocateMemory(size), size, this);
+    DirectMemory memory = new DirectMemory(DirectMemory.UNSAFE.allocateMemory(size), size, this);
+    DirectMemory.UNSAFE.setMemory(memory.address(), size, (byte) 0);
+    return memory;
   }
 
   @Override


### PR DESCRIPTION
This PR modifies direct/unsafe buffers to automatically initialize memory to `0`. This is something that is done automatically for arrays and other buffers, but does not occur when allocating memory directly. While this does imply some performance cost, the benefit is increased stability when using direct buffers in Copycat. All other buffer types are rightly expected to be initialized with empty bytes, so this should too for consistency within the `Buffer` abstraction.
