### PR TITLE
Fix infinite loop in automatic buffer resize

### DIFF
--- a/buffer/src/main/java/io/atomix/catalyst/buffer/AbstractBuffer.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/AbstractBuffer.java
@@ -412,7 +412,7 @@ public abstract class AbstractBuffer implements Buffer {
    * Calculates the next capacity that meets the given minimum capacity.
    */
   private long calculateCapacity(long minimumCapacity) {
-    long newCapacity = capacity;
+    long newCapacity = Math.min(Math.max(capacity, 2), minimumCapacity);
     while (newCapacity < Math.min(minimumCapacity, maxCapacity)) {
       newCapacity <<= 1;
     }

--- a/buffer/src/test/java/io/atomix/catalyst/buffer/BufferTest.java
+++ b/buffer/src/test/java/io/atomix/catalyst/buffer/BufferTest.java
@@ -551,4 +551,15 @@ public abstract class BufferTest {
     assertEquals(buffer.readLong(), 1234);
   }
 
+  public void testCapacity0Read() {
+    Buffer buffer = createBuffer(0, 1024);
+    assertEquals(buffer.readLong(), 0);
+  }
+
+  public void testCapacity0Write() {
+    Buffer buffer = createBuffer(0, 1024);
+    buffer.writeLong(10);
+    assertEquals(buffer.readLong(0), 10);
+  }
+
 }


### PR DESCRIPTION
This PR fixes an infinite loop when attempting to automatically scale a buffer with a `capacity` of `0`. Buffer scaling simply moves bytes to the left until the minimum required capacity (for a read or write) is met. But if the `capacity` is `0` then it will never change. So, this sets the capacity to a minimum of `max(2, minimumCapacity)` when scaling a buffer.
