### PR TITLE
Remove internal serializer from LocalTransport

### DIFF
--- a/local/src/main/java/io/atomix/catalyst/transport/LocalClient.java
+++ b/local/src/main/java/io/atomix/catalyst/transport/LocalClient.java
@@ -15,10 +15,8 @@
  */
 package io.atomix.catalyst.transport;
 
-import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.concurrent.Futures;
-import io.atomix.catalyst.util.concurrent.SingleThreadContext;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 
 import java.util.Collections;
@@ -35,17 +33,13 @@ import java.util.concurrent.ConcurrentHashMap;
 public class LocalClient implements Client {
   private final UUID id = UUID.randomUUID();
   private final LocalServerRegistry registry;
-  private final ThreadContext context;
   private final Set<LocalConnection> connections = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
   /**
    * @throws NullPointerException if any argument is null
    */
-  public LocalClient(LocalServerRegistry registry, Serializer serializer) {
-    Assert.notNull(registry, "registry");
-    Assert.notNull(serializer, "serializer");
-    this.registry = registry;
-    this.context = new SingleThreadContext("local-client-" + id.toString(), serializer.clone());
+  public LocalClient(LocalServerRegistry registry) {
+    this.registry = Assert.notNull(registry, "registry");
   }
 
   /**
@@ -64,7 +58,7 @@ public class LocalClient implements Client {
       return Futures.exceptionalFutureAsync(new TransportException("failed to connect"), context.executor());
     }
 
-    LocalConnection connection = new LocalConnection(this.context, connections);
+    LocalConnection connection = new LocalConnection(context, connections);
     connections.add(connection);
     return server.connect(connection).thenApplyAsync(v -> connection, context.executor());
   }

--- a/local/src/main/java/io/atomix/catalyst/transport/LocalTransport.java
+++ b/local/src/main/java/io/atomix/catalyst/transport/LocalTransport.java
@@ -15,8 +15,6 @@
  */
 package io.atomix.catalyst.transport;
 
-import io.atomix.catalyst.buffer.PooledDirectAllocator;
-import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
 
 /**
@@ -26,30 +24,19 @@ import io.atomix.catalyst.util.Assert;
  */
 public class LocalTransport implements Transport {
   private final LocalServerRegistry registry;
-  private final Serializer serializer;
 
   public LocalTransport(LocalServerRegistry registry) {
-    this(registry, new Serializer(new PooledDirectAllocator()));
-  }
-
-  /**
-   * @throws NullPointerException if any argument is null
-   */
-  public LocalTransport(LocalServerRegistry registry, Serializer serializer) {
-    Assert.notNull(registry, "registry");
-    Assert.notNull(serializer, "serializer");
-    this.registry = registry;
-    this.serializer = serializer;
+    this.registry = Assert.notNull(registry, "registry");
   }
 
   @Override
   public Client client() {
-    return new LocalClient(registry, serializer);
+    return new LocalClient(registry);
   }
 
   @Override
   public Server server() {
-    return new LocalServer(registry, serializer);
+    return new LocalServer(registry);
   }
 
 }


### PR DESCRIPTION
The `LocalTransport` currently creates its own `Serializer` and `ThreadContext` for use when no context is present. But transports should _only_ use contexts from calling threads. This PR removes the creation of `Serializer` and `ThreadContext` inside of `LocalTransport` and related classes.
