### PR TITLE
Require Java Serializable types to be whitelisted

### DIFF
--- a/serializer/src/main/java/io/atomix/catalyst/serializer/SerializeWith.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/SerializeWith.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.catalyst.serializer;
 
+import io.atomix.catalyst.serializer.util.CatalystSerializableSerializer;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/SerializerRegistry.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/SerializerRegistry.java
@@ -249,7 +249,10 @@ public class SerializerRegistry implements Cloneable {
 
       // If no factory was found, determine if a Java serializable factory can be used.
       if (factory == null) {
-        if (CatalystSerializable.class.isAssignableFrom(type)) {
+        SerializeWith serializeWith = type.getAnnotation(SerializeWith.class);
+        if (serializeWith != null && serializeWith.serializer() != null) {
+          factory = new DefaultTypeSerializerFactory(serializeWith.serializer());
+        } else if (CatalystSerializable.class.isAssignableFrom(type)) {
           factory = new DefaultTypeSerializerFactory(CatalystSerializableSerializer.class);
         } else if (Externalizable.class.isAssignableFrom(type)) {
           factory = new DefaultTypeSerializerFactory(ExternalizableSerializer.class);

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/SerializerRegistry.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/SerializerRegistry.java
@@ -16,10 +16,13 @@
 package io.atomix.catalyst.serializer;
 
 import io.atomix.catalyst.CatalystException;
+import io.atomix.catalyst.serializer.util.CatalystSerializableSerializer;
 import io.atomix.catalyst.serializer.util.ExternalizableSerializer;
+import io.atomix.catalyst.serializer.util.JavaSerializableSerializer;
 import io.atomix.catalyst.util.Hash;
 
 import java.io.Externalizable;
+import java.io.Serializable;
 import java.util.*;
 
 /**
@@ -150,6 +153,8 @@ public class SerializerRegistry implements Cloneable {
       return register(type, new DefaultTypeSerializerFactory(CatalystSerializableSerializer.class), id);
     } else if (Externalizable.class.isAssignableFrom(type)) {
       return register(type, new DefaultTypeSerializerFactory(ExternalizableSerializer.class), id);
+    } else if (Serializable.class.isAssignableFrom(type)) {
+      return register(type, new DefaultTypeSerializerFactory(JavaSerializableSerializer.class), id);
     } else {
       throw new CatalystException("failed to register serializable type: " + type);
     }

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/util/CatalystSerializableSerializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/util/CatalystSerializableSerializer.java
@@ -13,8 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.catalyst.serializer;
+package io.atomix.catalyst.serializer.util;
 
+import io.atomix.catalyst.serializer.CatalystSerializable;
+import io.atomix.catalyst.serializer.SerializationException;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.catalyst.serializer.TypeSerializer;
 import io.atomix.catalyst.util.ReferenceCounted;
 import io.atomix.catalyst.util.ReferenceFactory;
 import io.atomix.catalyst.util.ReferencePool;

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/util/JavaSerializableSerializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/util/JavaSerializableSerializer.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.catalyst.serializer.util;
+
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
+import io.atomix.catalyst.serializer.SerializationException;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.catalyst.serializer.TypeSerializer;
+
+import java.io.*;
+
+/**
+ * Java serializable serializer implementation.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class JavaSerializableSerializer<T> implements TypeSerializer<T> {
+
+  @Override
+  public void write(T object, BufferOutput<?> buffer, Serializer serializer) {
+    try (ByteArrayOutputStream os = new ByteArrayOutputStream(); ObjectOutputStream out = new ObjectOutputStream(os)) {
+      out.writeObject(object);
+      out.flush();
+      byte[] bytes = os.toByteArray();
+      buffer.writeUnsignedShort(bytes.length).write(bytes);
+    } catch (IOException e) {
+      throw new SerializationException("failed to serialize Java object", e);
+    }
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public T read(Class<T> type, BufferInput<?> buffer, Serializer serializer) {
+    byte[] bytes = new byte[buffer.readUnsignedShort()];
+    buffer.read(bytes);
+    try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes))) {
+      try {
+        return (T) in.readObject();
+      } catch (ClassNotFoundException e) {
+        throw new SerializationException("failed to deserialize Java object", e);
+      }
+    } catch (IOException e) {
+      throw new SerializationException("failed to deserialize Java object", e);
+    }
+  }
+
+}

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/util/PooledTypeSerializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/util/PooledTypeSerializer.java
@@ -13,21 +13,23 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.atomix.catalyst.serializer;
+package io.atomix.catalyst.serializer.util;
 
 import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.catalyst.serializer.TypeSerializer;
 import io.atomix.catalyst.util.ReferenceCounted;
 
 /**
  * Provides pooled object serialization.
  * <p>
  * The {@code PooledSerializer} is provided as a base class for {@link ReferenceCounted} object serializers. When objects
- * are deserialized by pooled serializers, available objects will be acquired via {@link PooledSerializer#acquire(Class)}
+ * are deserialized by pooled serializers, available objects will be acquired via {@link PooledTypeSerializer#acquire(Class)}
  * rather than being constructed new.
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public abstract class PooledSerializer<T extends ReferenceCounted<T>> implements TypeSerializer<T> {
+public abstract class PooledTypeSerializer<T extends ReferenceCounted<T>> implements TypeSerializer<T> {
 
   @Override
   public T read(Class<T> type, BufferInput<?> buffer, Serializer serializer) {

--- a/serializer/src/test/java/io/atomix/catalyst/serializer/SerializerTest.java
+++ b/serializer/src/test/java/io/atomix/catalyst/serializer/SerializerTest.java
@@ -293,6 +293,7 @@ public class SerializerTest {
    */
   public void testSerializeEnum() {
     Serializer serializer = new Serializer();
+    serializer.register(TestEnum.class);
     TestEnum test = TestEnum.THREE;
     Buffer buffer = serializer.writeObject(test).flip();
     Enum<?> result = serializer.readObject(buffer);
@@ -304,6 +305,7 @@ public class SerializerTest {
    */
   public void testSerializeEnumInterface() {
     Serializer serializer = new Serializer();
+    serializer.register(TestEnumImplements.class);
     TestEnumInterface test = TestEnumImplements.THREE;
     Buffer buffer = serializer.writeObject(test).flip();
     Enum<?> result = serializer.readObject(buffer);
@@ -426,6 +428,23 @@ public class SerializerTest {
     assertNull(((TestPojoWithSerializer) result.object).object);
     assertEquals(((TestPojoWithSerializer) result.object).string, "Hello world again!");
     assertEquals(result.string, "Hello world!");
+  }
+
+  /**
+   * Tests serializing an unregistered class.
+   */
+  @Test(expectedExceptions=SerializationException.class)
+  public void testSerializeUnregisteredFail() {
+    Serializer serializer = new Serializer();
+    serializer.readObject(serializer.writeObject(new TestUnregistered()).flip());
+  }
+
+  /**
+   * Tests serializing an unregistered class.
+   */
+  public void testSerializeUnregisteredSucceed() {
+    Serializer serializer = new Serializer().disableWhitelist();
+    serializer.readObject(serializer.writeObject(new TestUnregistered()).flip());
   }
 
   /**
@@ -582,7 +601,7 @@ public class SerializerTest {
     }
   }
 
-  @SerializeWith(id=0)
+  @SerializeWith(id=1)
   public static class TestSerializeWithId implements CatalystSerializable {
     protected byte primitive;
 
@@ -610,6 +629,9 @@ public class SerializerTest {
     public void readObject(BufferInput<?> buffer, Serializer serializer) {
       primitive = (byte) buffer.readByte();
     }
+  }
+
+  public static class TestUnregistered implements Serializable {
   }
 
   public enum TestEnum {

--- a/serializer/src/test/java/io/atomix/catalyst/serializer/SerializerTest.java
+++ b/serializer/src/test/java/io/atomix/catalyst/serializer/SerializerTest.java
@@ -457,6 +457,7 @@ public class SerializerTest {
    */
   public void testSerializeSerializable() {
     Serializer serializer = new Serializer();
+    serializer.register(TestSerializable.class);
     TestSerializable serializable = new TestSerializable();
     serializable.primitive = 100;
     serializable.string = "Hello world!";


### PR DESCRIPTION
This PR fixes the security issue in #14. However, rather than taking the approach of overriding `ObjectInputStream` to whitelist class names, classes are whitelisted at the `Serializer` level instead. This implements Java serialization simply as another `TypeSerializer`. This means `Serializable` types are serialized to the buffer. If a `Serializable` type is registered then the type will be serialized with a type ID. When the type is read during deserialization, the class will be loaded by the type ID. This ensures that only classes that have been whitelisted can be loaded when deserializing a registered `Serializable` type. If an attacker attempts to load an arbitrary class by injecting a serializable type ID, they can only load a registered class.

The flaw does still exist for `Serializable` types that are serialized without having been registered/whitelisted. If a `Serializable` object is serialized without having been registered, the class name will be serialized and deserialized. However, this feature is disabled by default. The user must explicitly disable whitelisting to allow class names to be serialized at all. If whitelisting is enabled, an exception will be thrown prior to loading any class during deserialization.
