### PR TITLE
Support abstract/default serializers

### DIFF
--- a/serializer/src/main/java/io/atomix/catalyst/serializer/collection/ArrayListSerializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/collection/ArrayListSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.catalyst.serializer.collection;
+
+import java.util.ArrayList;
+
+/**
+ * Array list serializer.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class ArrayListSerializer extends ListSerializer<ArrayList<?>> {
+
+  @Override
+  protected ArrayList<?> createList(int size) {
+    return new ArrayList<>(size);
+  }
+
+}

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/collection/HashMapSerializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/collection/HashMapSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.catalyst.serializer.collection;
+
+import java.util.HashMap;
+
+/**
+ * Hashmap serializer.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class HashMapSerializer extends MapSerializer<HashMap<?, ?>> {
+
+  @Override
+  protected HashMap<?, ?> createMap(int size) {
+    return new HashMap<>(size);
+  }
+
+}

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/collection/HashSetSerializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/collection/HashSetSerializer.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.catalyst.serializer.collection;
+
+import java.util.HashSet;
+
+/**
+ * Hash set serializer.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class HashSetSerializer extends SetSerializer<HashSet<?>> {
+
+  @Override
+  protected HashSet<?> createSet(int size) {
+    return new HashSet<>(size);
+  }
+
+}

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/collection/ListSerializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/collection/ListSerializer.java
@@ -20,7 +20,6 @@ import io.atomix.catalyst.buffer.BufferOutput;
 import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.serializer.TypeSerializer;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -28,10 +27,15 @@ import java.util.List;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class ListSerializer implements TypeSerializer<List<?>> {
+public abstract class ListSerializer<T extends List> implements TypeSerializer<T> {
+
+  /**
+   * Creates a new list object for deserialization.
+   */
+  protected abstract T createList(int size);
 
   @Override
-  public void write(List<?> object, BufferOutput buffer, Serializer serializer) {
+  public void write(T object, BufferOutput buffer, Serializer serializer) {
     buffer.writeUnsignedShort(object.size());
     for (Object value : object) {
       serializer.writeObject(value, buffer);
@@ -39,9 +43,10 @@ public class ListSerializer implements TypeSerializer<List<?>> {
   }
 
   @Override
-  public List<?> read(Class<List<?>> type, BufferInput buffer, Serializer serializer) {
+  @SuppressWarnings("unchecked")
+  public T read(Class<T> type, BufferInput buffer, Serializer serializer) {
     int size = buffer.readUnsignedShort();
-    List<Object> object = new ArrayList<>(size);
+    T object = createList(size);
     for (int i = 0; i < size; i++) {
       object.add(serializer.readObject(buffer));
     }

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/collection/MapSerializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/collection/MapSerializer.java
@@ -20,29 +20,36 @@ import io.atomix.catalyst.buffer.BufferOutput;
 import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.serializer.TypeSerializer;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Map serializer.
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class MapSerializer implements TypeSerializer<Map<?, ?>> {
+public abstract class MapSerializer<T extends Map> implements TypeSerializer<T> {
+
+  /**
+   * Creates a new map for deserialization.
+   */
+  protected abstract T createMap(int size);
 
   @Override
-  public void write(Map<?, ?> object, BufferOutput buffer, Serializer serializer) {
+  @SuppressWarnings("unchecked")
+  public void write(T object, BufferOutput buffer, Serializer serializer) {
     buffer.writeUnsignedShort(object.size());
-    for (Map.Entry<?, ?> entry : object.entrySet()) {
+    for (Map.Entry entry : (Set<Map.Entry>) object.entrySet()) {
       serializer.writeObject(entry.getKey(), buffer);
       serializer.writeObject(entry.getValue(), buffer);
     }
   }
 
   @Override
-  public Map<?, ?> read(Class<Map<?, ?>> type, BufferInput buffer, Serializer serializer) {
+  @SuppressWarnings("unchecked")
+  public T read(Class<T> type, BufferInput buffer, Serializer serializer) {
     int size = buffer.readUnsignedShort();
-    Map<Object, Object> object = new HashMap<>(size);
+    T object = createMap(size);
     for (int i = 0; i < size; i++) {
       Object key = serializer.readObject(buffer);
       Object value = serializer.readObject(buffer);

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/collection/SetSerializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/collection/SetSerializer.java
@@ -20,7 +20,6 @@ import io.atomix.catalyst.buffer.BufferOutput;
 import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.serializer.TypeSerializer;
 
-import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -28,10 +27,15 @@ import java.util.Set;
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
-public class SetSerializer implements TypeSerializer<Set<?>> {
+public abstract class SetSerializer<T extends Set> implements TypeSerializer<T> {
+
+  /**
+   * Creates a new set for deserialization.
+   */
+  protected abstract T createSet(int size);
 
   @Override
-  public void write(Set<?> object, BufferOutput buffer, Serializer serializer) {
+  public void write(T object, BufferOutput buffer, Serializer serializer) {
     buffer.writeUnsignedShort(object.size());
     for (Object value : object) {
       serializer.writeObject(value, buffer);
@@ -39,9 +43,10 @@ public class SetSerializer implements TypeSerializer<Set<?>> {
   }
 
   @Override
-  public Set<?> read(Class<Set<?>> type, BufferInput buffer, Serializer serializer) {
+  @SuppressWarnings("unchecked")
+  public T read(Class<T> type, BufferInput buffer, Serializer serializer) {
     int size = buffer.readUnsignedShort();
-    Set<Object> object = new HashSet<>(size);
+    T object = createSet(size);
     for (int i = 0; i < size; i++) {
       object.add(serializer.readObject(buffer));
     }

--- a/serializer/src/test/java/io/atomix/catalyst/serializer/SerializerTest.java
+++ b/serializer/src/test/java/io/atomix/catalyst/serializer/SerializerTest.java
@@ -317,7 +317,7 @@ public class SerializerTest {
    */
   public void testSerializeList() {
     Serializer serializer = new Serializer();
-    Buffer buffer = serializer.writeObject(Arrays.asList(1, 2, 3)).flip();
+    Buffer buffer = serializer.writeObject(new ArrayList<>(Arrays.asList(1, 2, 3))).flip();
     List<?> result = serializer.readObject(buffer);
     assertEquals(result, Arrays.asList(1, 2, 3));
   }


### PR DESCRIPTION
This PR significantly refactors the functionality of the serialization API to allow for different methods of serialization and class loading for abstract and concrete types. Previously, the `Serializer` allowed abstract types to be handled by a `TypeSerializer`. For instance, the `ListSerializer` serializes any type of list, but when the list is deserialized it is turned into an `ArrayList`. Instead, normal serializers now must be registered on specific concrete types. So, `ArrayListSerializer` only serializes and deserializes `ArrayList`s. 

But some types necessitate support for serialization of abstract types. Specifically, the `TimeZoneSerializer` no longer worked because `TimeZone` is an abstract class, and an internal `sun` class is the concrete type which can't be registered for portability. Thus, support for registering abstract types was provided. Abstract serializers essentially behave the same as the current `master` branch.

Finally, to support generic serialization frameworks, the concept of _default_ serializers was added as well. A default serializer would include `Serializable`, `CatalystSerializable`, `Externalizable`, `KryoSerializable`, and other serializable type interfaces like those. Default serializers are automatically applied to types registered without a specific serializer.
