### PR TITLE
Reorder type ID parameters

### DIFF
--- a/serializer/src/main/java/io/atomix/catalyst/serializer/JdkTypeResolver.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/JdkTypeResolver.java
@@ -61,12 +61,12 @@ public class JdkTypeResolver implements SerializableTypeResolver {
   public void resolve(SerializerRegistry registry) {
     int i = 176;
     for (Map.Entry<Class<?>, Class<? extends TypeSerializer<?>>> entry : SERIALIZERS.entrySet()) {
-      registry.register(entry.getKey(), entry.getValue(), i++);
+      registry.register(entry.getKey(), i++, entry.getValue());
     }
 
     i = 190;
     for (Map.Entry<Class<?>, Class<? extends TypeSerializer<?>>> entry : ABSTRACT_SERIALIZERS.entrySet()) {
-      registry.registerAbstract(entry.getKey(), entry.getValue(), i++);
+      registry.registerAbstract(entry.getKey(), i++, entry.getValue());
     }
 
     for (Map.Entry<Class<?>, Class<? extends TypeSerializer<?>>> entry : DEFAULT_SERIALIZERS.entrySet()) {

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/PrimitiveTypeResolver.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/PrimitiveTypeResolver.java
@@ -70,7 +70,7 @@ public class PrimitiveTypeResolver implements SerializableTypeResolver {
   public void resolve(SerializerRegistry registry) {
     int i = 128;
     for (Map.Entry<Class<?>, Class<? extends TypeSerializer<?>>> entry : SERIALIZERS.entrySet()) {
-      registry.register(entry.getKey(), entry.getValue(), i++);
+      registry.register(entry.getKey(), i++, entry.getValue());
     }
   }
 

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/Serializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/Serializer.java
@@ -364,12 +364,12 @@ public class Serializer {
    * factory will be copied and a new {@link TypeSerializer} will be instantiated for the clone.
    *
    * @param type The serializable type.
+   * @param id The serializable type ID.
    * @param serializer The serializer to register.
-   * @param id The type ID.
    * @return The serializer instance.
    */
-  public Serializer register(Class<?> type, Class<? extends TypeSerializer<?>> serializer, int id) {
-    registry.register(type, serializer, id);
+  public Serializer register(Class<?> type, int id, Class<? extends TypeSerializer<?>> serializer) {
+    registry.register(type, id, serializer);
     return this;
   }
 
@@ -391,12 +391,12 @@ public class Serializer {
    * the serializer factory will be copied and a new {@link TypeSerializer} will be instantiated for the clone.
    *
    * @param type The serializable type.
+   * @param id The serializable type ID.
    * @param factory The serializer factory to register.
-   * @param id The type ID.
    * @return The serializer instance.
    */
-  public Serializer register(Class<?> type, TypeSerializerFactory factory, int id) {
-    registry.register(type, factory, id);
+  public Serializer register(Class<?> type, int id, TypeSerializerFactory factory) {
+    registry.register(type, id, factory);
     return this;
   }
 
@@ -466,13 +466,13 @@ public class Serializer {
    * @param abstractType The abstract type for which to register the abstract serializer. Types that extend
    *                     the abstract type will be serialized using the given abstract serializer unless a
    *                     serializer has been registered for the specific concrete type.
-   * @param serializer The abstract type serializer with which to serialize instances of the abstract type.
    * @param id The serializable type ID with which to serialize the abstract class.
+   * @param serializer The abstract type serializer with which to serialize instances of the abstract type.
    * @return The serializer.
    * @throws NullPointerException if the {@code abstractType} or {@code serializer} is {@code null}
    */
-  public Serializer registerAbstract(Class<?> abstractType, Class<? extends TypeSerializer<?>> serializer, int id) {
-    registry.registerAbstract(abstractType, serializer, id);
+  public Serializer registerAbstract(Class<?> abstractType, int id, Class<? extends TypeSerializer<?>> serializer) {
+    registry.registerAbstract(abstractType, id, serializer);
     return this;
   }
 
@@ -492,13 +492,13 @@ public class Serializer {
    * @param abstractType The abstract type for which to register the abstract serializer. Types that extend
    *                     the abstract type will be serialized using the given abstract serializer unless a
    *                     serializer has been registered for the specific concrete type.
-   * @param factory The abstract type serializer factory with which to serialize instances of the abstract type.
    * @param id The serializable type ID with which to serialize the abstract class.
+   * @param factory The abstract type serializer factory with which to serialize instances of the abstract type.
    * @return The serializer.
    * @throws NullPointerException if the {@code abstractType} or {@code serializer} is {@code null}
    */
-  public Serializer registerAbstract(Class<?> abstractType, TypeSerializerFactory factory, int id) {
-    registry.registerAbstract(abstractType, factory, id);
+  public Serializer registerAbstract(Class<?> abstractType, int id, TypeSerializerFactory factory) {
+    registry.registerAbstract(abstractType, id, factory);
     return this;
   }
 

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/SerializerRegistry.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/SerializerRegistry.java
@@ -123,7 +123,7 @@ public class SerializerRegistry {
     if (baseType == null) {
       throw new RegistrationException("no default serializer found for type: " + type);
     }
-    return register(type, defaultFactories.get(baseType), id);
+    return register(type, id, defaultFactories.get(baseType));
   }
 
   /**
@@ -136,7 +136,7 @@ public class SerializerRegistry {
    */
   @SuppressWarnings("rawtypes")
   public SerializerRegistry register(Class<?> type, Class<? extends TypeSerializer> serializer) {
-    return register(type, new DefaultTypeSerializerFactory(serializer), calculateTypeId(type));
+    return register(type, calculateTypeId(type), new DefaultTypeSerializerFactory(serializer));
   }
 
   /**
@@ -148,21 +148,21 @@ public class SerializerRegistry {
    * @throws RegistrationException If the given {@code type} is already registered
    */
   public SerializerRegistry register(Class<?> type, TypeSerializerFactory factory) {
-    return register(type, factory, calculateTypeId(type));
+    return register(type, calculateTypeId(type), factory);
   }
 
   /**
    * Registers the given class for serialization.
    *
    * @param type The serializable class.
+   * @param id The serializable type ID.
    * @param serializer The serializer.
-   * @param id The serialization ID.
    * @return The serializer registry.
    * @throws RegistrationException If the given {@code type} is already registered
    */
   @SuppressWarnings("rawtypes")
-  public SerializerRegistry register(Class<?> type, Class<? extends TypeSerializer> serializer, int id) {
-    return register(type, new DefaultTypeSerializerFactory(serializer), id);
+  public SerializerRegistry register(Class<?> type, int id, Class<? extends TypeSerializer> serializer) {
+    return register(type, id, new DefaultTypeSerializerFactory(serializer));
   }
 
   /**
@@ -170,11 +170,11 @@ public class SerializerRegistry {
    *
    * @param type The serializable class.
    * @param factory The serializer factory.
-   * @param id The serialization ID.
+   * @param id The serializable type ID.
    * @return The serializer registry.
    * @throws RegistrationException If the given {@code type} or {@code id} is already registered
    */
-  public synchronized SerializerRegistry register(Class<?> type, TypeSerializerFactory factory, int id) {
+  public synchronized SerializerRegistry register(Class<?> type, int id, TypeSerializerFactory factory) {
     if (type == null)
       throw new NullPointerException("type cannot be null");
 
@@ -206,7 +206,7 @@ public class SerializerRegistry {
    * @return The serializer registry.
    */
   public SerializerRegistry registerAbstract(Class<?> abstractType, Class<? extends TypeSerializer> serializer) {
-    return registerAbstract(abstractType, new DefaultTypeSerializerFactory(serializer), calculateTypeId(abstractType));
+    return registerAbstract(abstractType, calculateTypeId(abstractType), new DefaultTypeSerializerFactory(serializer));
   }
 
   /**
@@ -217,30 +217,30 @@ public class SerializerRegistry {
    * @return The serializer registry.
    */
   public SerializerRegistry registerAbstract(Class<?> abstractType, TypeSerializerFactory factory) {
-    return registerAbstract(abstractType, factory, calculateTypeId(abstractType));
+    return registerAbstract(abstractType, calculateTypeId(abstractType), factory);
   }
 
   /**
    * Registers the given class as an abstract serializer for the given abstract type.
    *
    * @param abstractType The abstract type for which to register the serializer.
+   * @param id The serializable type ID.
    * @param serializer The serializer class.
-   * @param id The serializable type ID.
    * @return The serializer registry.
    */
-  public SerializerRegistry registerAbstract(Class<?> abstractType, Class<? extends TypeSerializer> serializer, int id) {
-    return registerAbstract(abstractType, new DefaultTypeSerializerFactory(serializer), id);
+  public SerializerRegistry registerAbstract(Class<?> abstractType, int id, Class<? extends TypeSerializer> serializer) {
+    return registerAbstract(abstractType, id, new DefaultTypeSerializerFactory(serializer));
   }
 
   /**
    * Registers the given class as an abstract serializer for the given abstract type.
    *
    * @param abstractType The abstract type for which to register the serializer.
-   * @param factory The serializer factory.
    * @param id The serializable type ID.
+   * @param factory The serializer factory.
    * @return The serializer registry.
    */
-  public SerializerRegistry registerAbstract(Class<?> abstractType, TypeSerializerFactory factory, int id) {
+  public SerializerRegistry registerAbstract(Class<?> abstractType, int id, TypeSerializerFactory factory) {
     abstractFactories.put(abstractType, factory);
     types.put(id, abstractType);
     ids.put(abstractType, id);


### PR DESCRIPTION
This PR reorganizes some of the method parameters when registering serializable types. The type `id` is now placed after the `Class` and before the `TypeSerializer` for the type. Type, ID, serializer.
