### PR TITLE
Clean up SSL implementation and add NettyTransport builder

### DIFF
--- a/netty/src/main/java/io/atomix/catalyst/transport/NettyClient.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/NettyClient.java
@@ -26,11 +26,7 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
-import io.netty.handler.logging.LogLevel;
-import io.netty.handler.logging.LoggingHandler;
-
 import io.netty.handler.ssl.SslHandler;
-import javax.net.ssl.SSLEngine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +45,6 @@ public class NettyClient implements Client {
   private static final ChannelHandler FIELD_PREPENDER = new LengthFieldPrepender(2);
 
   private final NettyTransport transport;
-  private NettyTls nettytls;
   private final Map<Channel, NettyConnection> connections = new ConcurrentHashMap<>();
 
   /**
@@ -74,8 +69,8 @@ public class NettyClient implements Client {
         @Override
         protected void initChannel(SocketChannel channel) throws Exception {
           ChannelPipeline pipeline = channel.pipeline();
-          if (transport.properties().sslEnabled() == true) {
-            pipeline.addFirst(new SslHandler(new NettyTls(transport.properties()).InitSSLEngine(true)));
+          if (transport.properties().sslEnabled()) {
+            pipeline.addFirst(new SslHandler(new NettyTls(transport.properties()).initSSLEngine(true)));
           }
           pipeline.addLast(FIELD_PREPENDER);
           pipeline.addLast(new LengthFieldBasedFrameDecoder(1024 * 64, 0, 2, 0, 2));

--- a/netty/src/main/java/io/atomix/catalyst/transport/NettyClient.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/NettyClient.java
@@ -70,7 +70,7 @@ public class NettyClient implements Client {
         protected void initChannel(SocketChannel channel) throws Exception {
           ChannelPipeline pipeline = channel.pipeline();
           if (transport.properties().sslEnabled()) {
-            pipeline.addFirst(new SslHandler(new NettyTls(transport.properties()).initSSLEngine(true)));
+            pipeline.addFirst(new SslHandler(new NettyTls(transport.properties()).initSslEngine(true)));
           }
           pipeline.addLast(FIELD_PREPENDER);
           pipeline.addLast(new LengthFieldBasedFrameDecoder(1024 * 64, 0, 2, 0, 2));

--- a/netty/src/main/java/io/atomix/catalyst/transport/NettyProperties.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/NettyProperties.java
@@ -132,9 +132,9 @@ public final class NettyProperties {
    * The SSL Protocol.
    */
   public SslProtocol sslProtocol() {
-    String protocol = reader.getString(SSL_PROTOCOL, DEFAULT_SSL_PROTOCOL);
+    String protocol = reader.getString(SSL_PROTOCOL, DEFAULT_SSL_PROTOCOL).replace(".", "_");
     try {
-      return SslProtocol.valueOf(protocol.replace(".", "_"));
+      return SslProtocol.valueOf(protocol);
     } catch (IllegalArgumentException e) {
       throw new ConfigurationException("unknown SSL protocol: " + protocol, e);
     }

--- a/netty/src/main/java/io/atomix/catalyst/transport/NettyProperties.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/NettyProperties.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.catalyst.transport;
 
+import io.atomix.catalyst.util.ConfigurationException;
 import io.atomix.catalyst.util.PropertiesReader;
 
 import java.util.Properties;
@@ -36,11 +37,11 @@ public final class NettyProperties {
 
   public static final String SSL_ENABLED = "ssl.enabled";
   public static final String SSL_PROTOCOL = "ssl.protocol";
-  public static final String SSL_TRUSTSTORE_PATH = "ssl.truststore.path";
-  public static final String SSL_TRUSTSTORE_PASSWORD = "ssl.truststore.password";
-  public static final String SSL_KEYSTORE_PATH = "ssl.keystore.path";
-  public static final String SSL_KEYSTORE_PASSWORD = "ssl.keystore.password";
-  public static final String SSL_KEYSTORE_KEY_PASSWORD = "ssl.keystore.keypassword";
+  public static final String SSL_TRUST_STORE_PATH = "ssl.trustStore.path";
+  public static final String SSL_TRUST_STORE_PASSWORD = "ssl.trustStore.password";
+  public static final String SSL_KEY_STORE_PATH = "ssl.keyStore.path";
+  public static final String SSL_KEY_STORE_PASSWORD = "ssl.keyStore.password";
+  public static final String SSL_KEY_STORE_KEY_PASSWORD = "ssl.keyStore.keyPassword";
 
   private static final int DEFAULT_THREADS = Runtime.getRuntime().availableProcessors();
   private static final int DEFAULT_CONNECT_TIMEOUT = 5000;
@@ -130,43 +131,48 @@ public final class NettyProperties {
   /**
    * The SSL Protocol.
    */
-  public String sslProtocol() {
-    return reader.getString(SSL_PROTOCOL, DEFAULT_SSL_PROTOCOL);
+  public SslProtocol sslProtocol() {
+    String protocol = reader.getString(SSL_PROTOCOL, DEFAULT_SSL_PROTOCOL);
+    try {
+      return SslProtocol.valueOf(protocol.replace(".", "_"));
+    } catch (IllegalArgumentException e) {
+      throw new ConfigurationException("unknown SSL protocol: " + protocol, e);
+    }
   }
 
   /**
-   * The SSL truststore path.
+   * The SSL trust store path.
    */
-  public String sslTruststorePath() {
-    return reader.getString(SSL_TRUSTSTORE_PATH, null);
+  public String sslTrustStorePath() {
+    return reader.getString(SSL_TRUST_STORE_PATH, null);
   }
 
   /**
-   * The SSL truststore password.
+   * The SSL trust store password.
    */
-  public String sslTruststorePassword() {
-    return reader.getString(SSL_TRUSTSTORE_PASSWORD, null);
+  public String sslTrustStorePassword() {
+    return reader.getString(SSL_TRUST_STORE_PASSWORD, null);
   }
 
   /**
-   * The SSL keystore path.
+   * The SSL key store path.
    */
-  public String sslKeystorePath() {
-    return reader.getString(SSL_KEYSTORE_PATH);
+  public String sslKeyStorePath() {
+    return reader.getString(SSL_KEY_STORE_PATH);
   }
 
   /**
-   * The SSL keystore password.
+   * The SSL key store password.
    */
-  public String sslKeystorePassword() {
-    return reader.getString(SSL_KEYSTORE_PASSWORD, null);
+  public String sslKeyStorePassword() {
+    return reader.getString(SSL_KEY_STORE_PASSWORD, null);
   }
 
   /**
-   * The SSL keystore key password.
+   * The SSL key store key password.
    */
-  public String sslKeystoreKeyPassword() {
-    return reader.getString(SSL_KEYSTORE_KEY_PASSWORD, null);
+  public String sslKeyStoreKeyPassword() {
+    return reader.getString(SSL_KEY_STORE_KEY_PASSWORD, null);
   }
 
 }

--- a/netty/src/main/java/io/atomix/catalyst/transport/NettyServer.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/NettyServer.java
@@ -95,7 +95,7 @@ public class NettyServer implements Server {
         public void initChannel(SocketChannel channel) throws Exception {
           ChannelPipeline pipeline = channel.pipeline();
           if (transport.properties().sslEnabled()) {
-            pipeline.addFirst(new SslHandler(new NettyTls(transport.properties()).initSSLEngine(false)));
+            pipeline.addFirst(new SslHandler(new NettyTls(transport.properties()).initSslEngine(false)));
           }
           pipeline.addLast(FIELD_PREPENDER);
           pipeline.addLast(new LengthFieldBasedFrameDecoder(1024 * 64, 0, 2, 0, 2));

--- a/netty/src/main/java/io/atomix/catalyst/transport/NettyServer.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/NettyServer.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.catalyst.transport;
 
-import io.atomix.catalyst.transport.NettyTls;
 import io.atomix.catalyst.util.Assert;
 import io.atomix.catalyst.util.concurrent.ThreadContext;
 import io.netty.bootstrap.ServerBootstrap;
@@ -30,9 +29,8 @@ import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
-import io.netty.util.concurrent.GlobalEventExecutor;
 import io.netty.handler.ssl.SslHandler;
-import javax.net.ssl.SSLEngine;
+import io.netty.util.concurrent.GlobalEventExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -96,8 +94,8 @@ public class NettyServer implements Server {
         @Override
         public void initChannel(SocketChannel channel) throws Exception {
           ChannelPipeline pipeline = channel.pipeline();
-          if (transport.properties().sslEnabled() == true) {
-            pipeline.addFirst(new SslHandler(new NettyTls(transport.properties()).InitSSLEngine(false)));
+          if (transport.properties().sslEnabled()) {
+            pipeline.addFirst(new SslHandler(new NettyTls(transport.properties()).initSSLEngine(false)));
           }
           pipeline.addLast(FIELD_PREPENDER);
           pipeline.addLast(new LengthFieldBasedFrameDecoder(1024 * 64, 0, 2, 0, 2));

--- a/netty/src/main/java/io/atomix/catalyst/transport/NettyTls.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/NettyTls.java
@@ -43,7 +43,7 @@ final class NettyTls {
    * @param client Indicates whether the engine is being initialized for a client.
    * @return The initialized SSL engine.
    */
-  public SSLEngine initSSLEngine(boolean client) throws Exception {
+  public SSLEngine initSslEngine(boolean client) throws Exception {
     // Load the keystore
     KeyStore keyStore = loadKeystore(properties.sslKeyStorePath(), properties.sslKeyStorePassword());
 

--- a/netty/src/main/java/io/atomix/catalyst/transport/NettyTls.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/NettyTls.java
@@ -15,71 +15,62 @@
  */
 package io.atomix.catalyst.transport;
 
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
 import io.atomix.catalyst.util.Assert;
-import java.io.FileInputStream;
-import java.security.KeyStore;
-import java.io.File;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.security.KeyStore;
 
 /**
  * Netty TLS.
  *
  * @author <a href="http://github.com/electrical">Richard Pijnenburg</a>
  */
-
-public class NettyTls {
-
+final class NettyTls {
   private static final Logger LOGGER = LoggerFactory.getLogger(NettyTls.class);
-  private static boolean ts_use_ks = true;
-  private static KeyStore ts;
-  private static NettyProperties properties;
+  private NettyProperties properties;
 
   public NettyTls(NettyProperties properties) {
     this.properties = properties;
   }
 
-  public SSLEngine InitSSLEngine(Boolean client) throws Exception {
-
-    if (properties.sslTruststorePath() != null) {
-      ts_use_ks = false;
-    }
-
+  /**
+   * Initializes an SSL engine.
+   *
+   * @param client Indicates whether the engine is being initialized for a client.
+   * @return The initialized SSL engine.
+   */
+  public SSLEngine initSSLEngine(boolean client) throws Exception {
     // Load the keystore
-    KeyStore ks = loadKeystore(properties.sslKeystorePath(), properties.sslKeystorePassword());
+    KeyStore keyStore = loadKeystore(properties.sslKeyStorePath(), properties.sslKeyStorePassword());
 
     // Setup the keyManager to use our keystore
-    KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
-    kmf.init(ks, KeyStoreKeyPass(properties));
+    KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
+    keyManagerFactory.init(keyStore, keyStoreKeyPass(properties));
 
     // Setup the Trust keystore
-    if (ts_use_ks == false) {
+    KeyStore trustStore;
+    if (properties.sslTrustStorePath() != null) {
       // Use the separate Trust keystore
-      LOGGER.debug("Using separate Truststore");
-      KeyStore ts = loadKeystore(properties.sslTruststorePath(), properties.sslTruststorePassword());
+      LOGGER.debug("Using separate trust store");
+      trustStore = loadKeystore(properties.sslTrustStorePath(), properties.sslTrustStorePassword());
     } else {
       // Reuse the existing keystore
-      ts = ks;
-      LOGGER.debug("Using Keystore as Truststore");
+      trustStore = keyStore;
+      LOGGER.debug("Using key store as trust store");
     }
 
-    TrustManagerFactory tmFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
-    tmFactory.init(ts);
+    TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+    trustManagerFactory.init(trustStore);
 
-    KeyManager[] km = kmf.getKeyManagers();
-    TrustManager[] tm = tmFactory.getTrustManagers();
+    KeyManager[] keyManagers = keyManagerFactory.getKeyManagers();
+    TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
 
     SSLContext sslContext = SSLContext.getInstance("TLS");
-    sslContext.init(km, tm, null);
+    sslContext.init(keyManagers, trustManagers, null);
     SSLEngine sslEngine = sslContext.createSSLEngine();
     sslEngine.setUseClientMode(client);
     sslEngine.setWantClientAuth(true);
@@ -100,11 +91,11 @@ public class NettyTls {
     return ks;
   }
 
-  private char[] KeyStoreKeyPass(NettyProperties properties) throws Exception {
-    if (properties.sslKeystoreKeyPassword() != null) {
-      return properties.sslKeystoreKeyPassword().toCharArray();
+  private char[] keyStoreKeyPass(NettyProperties properties) throws Exception {
+    if (properties.sslKeyStoreKeyPassword() != null) {
+      return properties.sslKeyStoreKeyPassword().toCharArray();
     } else {
-      return properties.sslKeystorePassword().toCharArray();
+      return properties.sslKeyStorePassword().toCharArray();
     }
   }
 

--- a/netty/src/main/java/io/atomix/catalyst/transport/NettyTransport.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/NettyTransport.java
@@ -29,6 +29,16 @@ import java.util.concurrent.ThreadFactory;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public class NettyTransport implements Transport {
+
+  /**
+   * Returns a new Netty transport builder.
+   *
+   * @return A new Netty transport builder.
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
   private final NettyProperties properties;
   private final EventLoopGroup eventLoopGroup;
 
@@ -79,6 +89,222 @@ public class NettyTransport implements Transport {
     try {
       eventLoopGroup.shutdownGracefully().sync();
     } catch (InterruptedException e) {
+    }
+  }
+
+  /**
+   * Netty transport builder.
+   */
+  public static class Builder implements Transport.Builder {
+    private final Properties properties = new Properties();
+
+    private Builder() {
+    }
+
+    /**
+     * Sets the number of Netty event loop threads.
+     *
+     * @param threads The number of Netty event loop threads.
+     * @return The Netty transport builder.
+     */
+    public Builder withThreads(int threads) {
+      properties.setProperty(NettyProperties.THREADS, String.valueOf(Assert.argNot(threads, threads <= 0, "threads must be positive")));
+      return this;
+    }
+
+    /**
+     * Sets the Netty connect timeout.
+     *
+     * @param timeout The connect timeout.
+     * @return The Netty transport builder.
+     */
+    public Builder withConnectTimeout(int timeout) {
+      properties.setProperty(NettyProperties.CONNECT_TIMEOUT, String.valueOf(Assert.argNot(timeout, timeout <= 0, "timeout must be positive")));
+      return this;
+    }
+
+    /**
+     * Sets the send buffer size.
+     *
+     * @param sendBufferSize The send buffer size.
+     * @return The Netty transport builder.
+     */
+    public Builder withSendBufferSize(int sendBufferSize) {
+      properties.setProperty(NettyProperties.SEND_BUFFER_SIZE, String.valueOf(Assert.argNot(sendBufferSize, sendBufferSize <= 0, "buffer size must be positive")));
+      return this;
+    }
+
+    /**
+     * Sets the receive buffer size.
+     *
+     * @param receiveBufferSize The receive buffer size.
+     * @return The Netty transport builder.
+     */
+    public Builder withReceiveBufferSize(int receiveBufferSize) {
+      properties.setProperty(NettyProperties.RECEIVE_BUFFER_SIZE, String.valueOf(Assert.argNot(receiveBufferSize, receiveBufferSize <= 0, "buffer size must be positive")));
+      return this;
+    }
+
+    /**
+     * Enables the SO_REUSEADDR option.
+     *
+     * @return The Netty transport builder.
+     */
+    public Builder withReuseAddress() {
+      return withReuseAddress(true);
+    }
+
+    /**
+     * Sets the SO_REUSEADDR option.
+     *
+     * @param reuseAddress Whether to enable SO_REUSEADDR.
+     * @return The Netty transport builder.
+     */
+    public Builder withReuseAddress(boolean reuseAddress) {
+      properties.setProperty(NettyProperties.REUSE_ADDRESS, String.valueOf(reuseAddress));
+      return this;
+    }
+
+    /**
+     * Enables the SO_KEEPALIVE option.
+     *
+     * @return The Netty transport builder.
+     */
+    public Builder withTcpKeepAlive() {
+      return withTcpKeepAlive(true);
+    }
+
+    /**
+     * Sets the SO_KEEPALIVE option.
+     *
+     * @param tcpKeepAlive Whether to enable SO_KEEPALIVE.
+     * @return The Netty transport builder.
+     */
+    public Builder withTcpKeepAlive(boolean tcpKeepAlive) {
+      properties.setProperty(NettyProperties.TCP_KEEP_ALIVE, String.valueOf(tcpKeepAlive));
+      return this;
+    }
+
+    /**
+     * Enables the TCP_NODELAY option.
+     *
+     * @return The Netty transport builder.
+     */
+    public Builder withTcpNoDelay() {
+      return withTcpNoDelay(true);
+    }
+
+    /**
+     * Sets the TCP_NODELAY option.
+     *
+     * @param tcpNoDelay Whether to enable TCP_NODELAY.
+     * @return The Netty transport builder.
+     */
+    public Builder withTcpNoDelay(boolean tcpNoDelay) {
+      properties.setProperty(NettyProperties.TCP_NO_DELAY, String.valueOf(tcpNoDelay));
+      return this;
+    }
+
+    /**
+     * Sets the TCP accept backlog.
+     *
+     * @param acceptBacklog The accept backlog.
+     * @return The Netty transport builder.
+     */
+    public Builder withAcceptBacklog(int acceptBacklog) {
+      properties.setProperty(NettyProperties.ACCEPT_BACKLOG, String.valueOf(Assert.argNot(acceptBacklog, acceptBacklog <= 0, "accept backlog must be positive")));
+      return this;
+    }
+
+    /**
+     * Enables SSL.
+     *
+     * @return The Netty transport builder.
+     */
+    public Builder withSsl() {
+      return withSsl(true);
+    }
+
+    /**
+     * Sets whether to enable SSL.
+     *
+     * @param sslEnabled Whether to enable SSL.
+     * @return The Netty transport builder.
+     */
+    public Builder withSsl(boolean sslEnabled) {
+      properties.setProperty(NettyProperties.SSL_ENABLED, String.valueOf(sslEnabled));
+      return this;
+    }
+
+    /**
+     * Sets the SSL protocol.
+     *
+     * @param sslProtocol The SSL protocol.
+     * @return The Netty transport builder.
+     */
+    public Builder withSslProtocol(SslProtocol sslProtocol) {
+      properties.setProperty(NettyProperties.SSL_PROTOCOL, Assert.notNull(sslProtocol, "sslProtocol").name().replace("_", "."));
+      return this;
+    }
+
+    /**
+     * Sets the SSL trust store path.
+     *
+     * @param trustStorePath The trust store path.
+     * @return The Netty transport builder.
+     */
+    public Builder withTrustStorePath(String trustStorePath) {
+      properties.setProperty(NettyProperties.SSL_TRUST_STORE_PATH, Assert.notNull(trustStorePath, "trustStorePath"));
+      return this;
+    }
+
+    /**
+     * Sets the SSL trust store password.
+     *
+     * @param trustStorePassword The trust store password.
+     * @return The Netty transport builder.
+     */
+    public Builder withTrustStorePassword(String trustStorePassword) {
+      properties.setProperty(NettyProperties.SSL_TRUST_STORE_PASSWORD, Assert.notNull(trustStorePassword, "trustStorePassword"));
+      return this;
+    }
+
+    /**
+     * Sets the SSL key store path.
+     *
+     * @param keyStorePath The key store path.
+     * @return The Netty transport builder.
+     */
+    public Builder withKeyStorePath(String keyStorePath) {
+      properties.setProperty(NettyProperties.SSL_KEY_STORE_PATH, Assert.notNull(keyStorePath, "keyStorePath"));
+      return this;
+    }
+
+    /**
+     * Sets the SSL key store password.
+     *
+     * @param trustStorePassword The key store password.
+     * @return The Netty transport builder.
+     */
+    public Builder withKeyStorePassword(String trustStorePassword) {
+      properties.setProperty(NettyProperties.SSL_KEY_STORE_PASSWORD, Assert.notNull(trustStorePassword, "trustStorePassword"));
+      return this;
+    }
+
+    /**
+     * Sets the SSL key store key password.
+     *
+     * @param keyStoreKeyPassword The key store key password.
+     * @return The Netty transport builder.
+     */
+    public Builder withKeyStoreKeyPassword(String keyStoreKeyPassword) {
+      properties.setProperty(NettyProperties.SSL_KEY_STORE_KEY_PASSWORD, Assert.notNull(keyStoreKeyPassword, "trustStorePassword"));
+      return this;
+    }
+
+    @Override
+    public Transport build() {
+      return new NettyTransport(properties);
     }
   }
 

--- a/netty/src/main/java/io/atomix/catalyst/transport/SslProtocol.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/SslProtocol.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.catalyst.transport;
+
+/**
+ * SSL protocol constants.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public enum SslProtocol {
+
+  /**
+   * SSLv3 protocol.
+   */
+  SSLv3,
+
+  /**
+   * TLSv1 protocol.
+   */
+  TLSv1,
+
+  /**
+   * TLSv1.1 protocol.
+   */
+  TLSv1_1,
+
+  /**
+   * TLSv1.2 protocol.
+   */
+  TLSv1_2
+
+}

--- a/netty/src/test/java/io/atomix/catalyst/transport/NettyTransportTest.java
+++ b/netty/src/test/java/io/atomix/catalyst/transport/NettyTransportTest.java
@@ -24,10 +24,8 @@ import org.testng.annotations.Test;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
-import java.util.concurrent.CompletableFuture;
-
-import io.atomix.catalyst.util.PropertiesReader;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 /**
  * Netty transport test.
  *
@@ -86,15 +84,14 @@ public class NettyTransportTest extends ConcurrentTestCase {
     await(1000, 2);
   }
 
-  @Test(enabled = false)
+  @Test(enabled=false)
   // This test fails because of cert validation
   // Keeping it in here for own testing and as an example
   public void testSendReceiveSSL() throws Throwable {
-
     Properties properties = new Properties();
     properties.put(NettyProperties.SSL_ENABLED, "true");
-    properties.put(NettyProperties.SSL_KEYSTORE_PATH, "src/test/resources/test.keystore");
-    properties.put(NettyProperties.SSL_KEYSTORE_PASSWORD, "password");
+    properties.put(NettyProperties.SSL_KEY_STORE_PATH, "src/test/resources/test.keystore");
+    properties.put(NettyProperties.SSL_KEY_STORE_PASSWORD, "password");
     NettyProperties nettyProperties = new NettyProperties(properties);
 
     Transport transport = new NettyTransport(nettyProperties);

--- a/netty/src/test/java/io/atomix/catalyst/transport/NettyTransportTest.java
+++ b/netty/src/test/java/io/atomix/catalyst/transport/NettyTransportTest.java
@@ -38,7 +38,6 @@ public class NettyTransportTest extends ConcurrentTestCase {
    * Tests connecting to a server and sending a message.
    */
   public void testSendReceive() throws Throwable {
-
     Properties properties = new Properties();
     NettyProperties nettyProperties = new NettyProperties(properties);
 

--- a/transport/src/main/java/io/atomix/catalyst/transport/Transport.java
+++ b/transport/src/main/java/io/atomix/catalyst/transport/Transport.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.catalyst.transport;
 
+import io.atomix.catalyst.util.Builder;
+
 /**
  * Transport provider.
  * <p>
@@ -49,6 +51,12 @@ public interface Transport extends AutoCloseable {
    */
   @Override
   default void close() {
+  }
+
+  /**
+   * Transport builder.
+   */
+  interface Builder extends io.atomix.catalyst.util.Builder<Transport> {
   }
 
 }


### PR DESCRIPTION
This PR adds a `Builder` to `NettyTransport` to handle construction of transports programmatically, including with SSL configurations. Also clean up some SSL code. Will comment inline on those changes...
