### PR TITLE
Add abstract properties serializer

### DIFF
--- a/serializer/src/main/java/io/atomix/catalyst/serializer/JdkTypeResolver.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/JdkTypeResolver.java
@@ -50,6 +50,7 @@ public class JdkTypeResolver implements SerializableTypeResolver {
     put(Calendar.class, CalendarSerializer.class);
     put(TimeZone.class, TimeZoneSerializer.class);
     put(Map.Entry.class, MapEntrySerializer.class);
+    put(Properties.class, PropertiesSerializer.class);
   }};
 
   @SuppressWarnings("unchecked")

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/util/PropertiesSerializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/util/PropertiesSerializer.java
@@ -15,12 +15,8 @@
  */
 package io.atomix.catalyst.serializer.util;
 
-import io.atomix.catalyst.buffer.BufferInput;
-import io.atomix.catalyst.buffer.BufferOutput;
-import io.atomix.catalyst.serializer.Serializer;
-import io.atomix.catalyst.serializer.TypeSerializer;
+import io.atomix.catalyst.serializer.collection.MapSerializer;
 
-import java.util.Map;
 import java.util.Properties;
 
 /**
@@ -28,24 +24,11 @@ import java.util.Properties;
  *
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
-public class PropertiesSerializer implements TypeSerializer<Properties> {
+public class PropertiesSerializer extends MapSerializer<Properties> {
 
   @Override
-  public void write(Properties object, BufferOutput buffer, Serializer serializer) {
-    buffer.writeUnsignedShort(object.size());
-    for (Map.Entry<Object, Object> entry : object.entrySet()) {
-      buffer.writeString(entry.getKey().toString()).writeString((String) entry.getValue());
-    }
-  }
-
-  @Override
-  public Properties read(Class<Properties> type, BufferInput buffer, Serializer serializer) {
-    Properties properties = new Properties();
-    int size = buffer.readUnsignedShort();
-    for (int i = 0; i < size; i++) {
-      properties.setProperty(buffer.readString(), buffer.readString());
-    }
-    return properties;
+  protected Properties createMap(int size) {
+    return new Properties();
   }
 
 }

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/util/PropertiesSerializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/util/PropertiesSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.catalyst.serializer.util;
+
+import io.atomix.catalyst.buffer.BufferInput;
+import io.atomix.catalyst.buffer.BufferOutput;
+import io.atomix.catalyst.serializer.Serializer;
+import io.atomix.catalyst.serializer.TypeSerializer;
+
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Properties serializer.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class PropertiesSerializer implements TypeSerializer<Properties> {
+
+  @Override
+  public void write(Properties object, BufferOutput buffer, Serializer serializer) {
+    buffer.writeUnsignedShort(object.size());
+    for (Map.Entry<Object, Object> entry : object.entrySet()) {
+      buffer.writeString(entry.getKey().toString()).writeString((String) entry.getValue());
+    }
+  }
+
+  @Override
+  public Properties read(Class<Properties> type, BufferInput buffer, Serializer serializer) {
+    Properties properties = new Properties();
+    int size = buffer.readUnsignedShort();
+    for (int i = 0; i < size; i++) {
+      properties.setProperty(buffer.readString(), buffer.readString());
+    }
+    return properties;
+  }
+
+}

--- a/serializer/src/test/java/io/atomix/catalyst/serializer/SerializerTest.java
+++ b/serializer/src/test/java/io/atomix/catalyst/serializer/SerializerTest.java
@@ -467,6 +467,17 @@ public class SerializerTest {
   }
 
   /**
+   * Tests serializing properties.
+   */
+  public void testSerializeProperties() {
+    Serializer serializer = new Serializer();
+    Properties properties = new Properties();
+    properties.setProperty("foo", "bar");
+    Properties result = serializer.readObject(serializer.writeObject(properties).flip());
+    assertEquals(result.getProperty("foo"), "bar");
+  }
+
+  /**
    * Tests serializing a POJO with a serializer.
    */
   public void testSerializeSerializer() {


### PR DESCRIPTION
This PR adds an abstract serializer for `Properties`. Implementing it as an abstract serializer allows extended `Properties` classes to be serialized as `Properties`. This serializer is used in Atomix for resource configuration.
