### PR TITLE
Construct Addresses using host:port formatted strings.

### DIFF
--- a/transport/src/main/java/io/atomix/catalyst/transport/Address.java
+++ b/transport/src/main/java/io/atomix/catalyst/transport/Address.java
@@ -36,6 +36,20 @@ public class Address implements CatalystSerializable {
   public Address() {
   }
 
+  public Address(String address) {
+    Assert.notNull(address, "address");
+    String[] components = address.split(":");
+    Assert.arg(components.length == 2, "%s must contain address:port", address);
+
+    this.host = components[0];
+    try {
+      this.port = Integer.parseInt(components[1]);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(components[1] + " is not a number");
+    }
+    this.address = new InetSocketAddress(host, port);
+  }
+
   public Address(Address address) {
     this(address.host, address.port, Assert.notNull(address, "address").address);
   }

--- a/transport/src/test/java/io/atomix/catalyst/transport/AddressTest.java
+++ b/transport/src/test/java/io/atomix/catalyst/transport/AddressTest.java
@@ -1,0 +1,24 @@
+package io.atomix.catalyst.transport;
+
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+@Test
+public class AddressTest {
+  public void shouldConstructFromString() {
+    Address address = new Address("localhost:5000");
+    assertEquals(address.host(), "localhost");
+    assertEquals(address.port(), 5000);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void shouldThrowOnMissingPort() {
+    new Address("localhost:");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void shouldThrowOnInvalidPort() {
+    new Address("localhost:foo");
+  }
+}


### PR DESCRIPTION
This will make it quicker/easier to construct addresses from CLI args for standalone servers.
