### PR TITLE
Support using custom ClassLoaders when deserializing Class objects.

### DIFF
--- a/serializer/src/main/java/io/atomix/catalyst/serializer/lang/ClassSerializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/lang/ClassSerializer.java
@@ -36,7 +36,8 @@ public class ClassSerializer implements TypeSerializer<Class<?>> {
   @Override
   public Class<?> read(Class<Class<?>> type, BufferInput buffer, Serializer serializer) {
     try {
-      return Class.forName(buffer.readUTF8());
+      String className = buffer.readUTF8();
+      return serializer.getClassLoader(className).loadClass(className);
     } catch (ClassNotFoundException e) {
       throw new SerializationException(e);
     }


### PR DESCRIPTION
This PR adds support for registering a ClassLoader for a class with the Serializer. If a ClassLoader is registered it will be used to resurrect those class objects, otherwise the default ClassLoader will be used.
This PR addresses https://github.com/atomix/atomix/issues/153
