### PR TITLE
Avoid reverse dns lookups in Address::writeObject

### DIFF
--- a/transport/src/main/java/io/atomix/catalyst/transport/Address.java
+++ b/transport/src/main/java/io/atomix/catalyst/transport/Address.java
@@ -97,7 +97,7 @@ public class Address implements CatalystSerializable {
 
   @Override
   public void writeObject(BufferOutput<?> buffer, Serializer serializer) {
-    buffer.writeUTF8(address.getHostName()).writeInt(address.getPort());
+    buffer.writeUTF8(host()).writeInt(port());
   }
 
   @Override


### PR DESCRIPTION
This PR eliminates expensive reverse dns lookups in the serialization code for Address.
