### PR TITLE
Cache Class::getEnclosingClass call results

### DIFF
--- a/serializer/src/main/java/io/atomix/catalyst/util/LRUCache.java
+++ b/serializer/src/main/java/io/atomix/catalyst/util/LRUCache.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.catalyst.util;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A fixed capacity map that automatically makes room for a new entry when the map is full by evicting the least
+ * recently accessed entry.
+ * <p>
+ * This implementation is not synchronized. Concurrent access to a LRUCache from multiple threads
+ * must be synchronized externally.
+ *
+ * @param <K> key type.
+ * @param <V> value type.
+ */
+@SuppressWarnings("serial")
+public class LRUCache<K, V> extends LinkedHashMap<K, V> {
+  private final int maxSize;
+
+  public LRUCache(int maxSize) {
+    super(16, 0.75f, true);
+    this.maxSize = Assert.arg(maxSize, maxSize > 0, "maxSize must be positive");
+  }
+
+  @Override
+  protected boolean removeEldestEntry(Map.Entry<K,V> eldest) {
+    return size() > maxSize;
+  }
+}

--- a/serializer/src/test/java/io/atomix/catalyst/util/LRUCacheTest.java
+++ b/serializer/src/test/java/io/atomix/catalyst/util/LRUCacheTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.catalyst.util;
+
+import static org.testng.Assert.*;
+
+import org.testng.annotations.Test;
+
+@Test
+public class LRUCacheTest {
+
+  public void testLRUBehavior() {
+    LRUCache<String, String> cache = new LRUCache<>(2);
+    cache.put("key1", "v1");
+    cache.put("key2", "v2");
+
+    // key3 should replace key1
+    cache.put("key3", "v3");
+    assertFalse(cache.containsKey("key1"));
+
+    // this marks key2 as most recently used
+    assertEquals("v2", cache.get("key2"));
+
+    // key4 should replace key3
+    cache.put("key4", "v4");
+    assertFalse(cache.containsKey("key3"));
+  }
+}


### PR DESCRIPTION
This PR attempts to relieve a CPU hot spot in the Serializer::writeObject by caching results of the relatively expensive Class::getEnclosingClass method calls.

Also in this PR is a simple LRUCache utility.
