### PR TITLE
Handle null strings in Netty buffers

### DIFF
--- a/netty/src/main/java/io/atomix/catalyst/transport/ByteBufInput.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/ByteBufInput.java
@@ -162,9 +162,14 @@ final class ByteBufInput implements BufferInput<ByteBufInput> {
 
   @Override
   public String readUTF8() {
-    byte[] bytes = new byte[buffer.readUnsignedShort()];
-    buffer.readBytes(bytes);
-    return new String(bytes, StandardCharsets.UTF_8);
+    int nullByte = buffer.readByte();
+    if (nullByte == 0) {
+      return null;
+    } else {
+      byte[] bytes = new byte[buffer.readUnsignedShort()];
+      buffer.readBytes(bytes);
+      return new String(bytes, StandardCharsets.UTF_8);
+    }
   }
 
   @Override

--- a/netty/src/main/java/io/atomix/catalyst/transport/ByteBufOutput.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/ByteBufOutput.java
@@ -195,9 +195,14 @@ final class ByteBufOutput implements BufferOutput<ByteBufOutput> {
 
   @Override
   public ByteBufOutput writeUTF8(String s) {
-    byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
-    checkWrite(Bytes.SHORT + bytes.length);
-    buffer.writeShort(bytes.length).writeBytes(bytes);
+    if (s == null) {
+      checkWrite(Bytes.BYTE);
+      buffer.writeByte(0);
+    } else {
+      byte[] bytes = s.getBytes(StandardCharsets.UTF_8);
+      checkWrite(Bytes.BYTE + Bytes.SHORT + bytes.length);
+      buffer.writeByte(1).writeShort(bytes.length).writeBytes(bytes);
+    }
     return this;
   }
 


### PR DESCRIPTION
This PR fixes an NPE due to inconsistencies between core `Buffer`s and the Netty `BufferOutput` and `BufferInput` implementation. Core buffers allow `null` strings to be written and read. This PR adds the same functionality to Netty buffers.
