### PR TITLE
Add blocking detection to ThreadContext

### DIFF
--- a/common/src/main/java/io/atomix/catalyst/util/concurrent/BlockingFuture.java
+++ b/common/src/main/java/io/atomix/catalyst/util/concurrent/BlockingFuture.java
@@ -15,8 +15,6 @@
  */
 package io.atomix.catalyst.util.concurrent;
 
-import io.atomix.catalyst.util.Assert;
-
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -27,15 +25,11 @@ import java.util.concurrent.TimeoutException;
  * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
  */
 public class BlockingFuture<T> extends ComposableFuture<T> {
-  private final ThreadContext context;
-
-  public BlockingFuture(ThreadContext context) {
-    this.context = Assert.notNull(context, "context");
-  }
 
   @Override
   public T get() throws InterruptedException, ExecutionException {
-    if (context.isCurrentContext()) {
+    ThreadContext context = ThreadContext.currentContext();
+    if (context != null) {
       context.block();
       try {
         return super.get();
@@ -48,7 +42,8 @@ public class BlockingFuture<T> extends ComposableFuture<T> {
 
   @Override
   public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
-    if (context.isCurrentContext()) {
+    ThreadContext context = ThreadContext.currentContext();
+    if (context != null) {
       context.block();
       try {
         return super.get(timeout, unit);
@@ -61,7 +56,8 @@ public class BlockingFuture<T> extends ComposableFuture<T> {
 
   @Override
   public T join() {
-    if (context.isCurrentContext()) {
+    ThreadContext context = ThreadContext.currentContext();
+    if (context != null) {
       context.block();
       try {
         return super.join();

--- a/common/src/main/java/io/atomix/catalyst/util/concurrent/BlockingFuture.java
+++ b/common/src/main/java/io/atomix/catalyst/util/concurrent/BlockingFuture.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.catalyst.util.concurrent;
+
+import io.atomix.catalyst.util.Assert;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * {@link java.util.concurrent.CompletableFuture} implementation that aids in detecting blocked threads.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class BlockingFuture<T> extends ComposableFuture<T> {
+  private final ThreadContext context;
+
+  public BlockingFuture(ThreadContext context) {
+    this.context = Assert.notNull(context, "context");
+  }
+
+  @Override
+  public T get() throws InterruptedException, ExecutionException {
+    if (context.isCurrentContext()) {
+      context.block();
+      try {
+        return super.get();
+      } finally {
+        context.unblock();
+      }
+    }
+    return super.get();
+  }
+
+  @Override
+  public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    if (context.isCurrentContext()) {
+      context.block();
+      try {
+        return super.get(timeout, unit);
+      } finally {
+        context.unblock();
+      }
+    }
+    return super.get(timeout, unit);
+  }
+
+  @Override
+  public T join() {
+    if (context.isCurrentContext()) {
+      context.block();
+      try {
+        return super.join();
+      } finally {
+        context.unblock();
+      }
+    }
+    return super.join();
+  }
+}

--- a/common/src/main/java/io/atomix/catalyst/util/concurrent/NonBlockingFuture.java
+++ b/common/src/main/java/io/atomix/catalyst/util/concurrent/NonBlockingFuture.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package io.atomix.catalyst.util.concurrent;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * A future that can't be blocked.
+ *
+ * @author <a href="http://github.com/kuujo>Jordan Halterman</a>
+ */
+public class NonBlockingFuture<T> extends CompletableFuture<T> {
+  @Override
+  public T join() {
+    throw new UnsupportedOperationException("cannot block the thread");
+  }
+
+  @Override
+  public T get() throws InterruptedException, ExecutionException {
+    throw new UnsupportedOperationException("cannot block the thread");
+  }
+
+  @Override
+  public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    throw new UnsupportedOperationException("cannot block the thread");
+  }
+}

--- a/common/src/main/java/io/atomix/catalyst/util/concurrent/SingleThreadContext.java
+++ b/common/src/main/java/io/atomix/catalyst/util/concurrent/SingleThreadContext.java
@@ -21,6 +21,7 @@ public class SingleThreadContext implements ThreadContext {
   private static final Logger LOGGER = LoggerFactory.getLogger(SingleThreadContext.class);
   private final ScheduledExecutorService executor;
   private final Serializer serializer;
+  private volatile boolean blocked;
   private final Executor wrappedExecutor = new Executor() {
     @Override
     public void execute(Runnable command) {
@@ -84,6 +85,21 @@ public class SingleThreadContext implements ThreadContext {
       throw new IllegalStateException("failed to initialize thread state", e);
     }
     return thread.get();
+  }
+
+  @Override
+  public void block() {
+    this.blocked = true;
+  }
+
+  @Override
+  public void unblock() {
+    this.blocked = false;
+  }
+
+  @Override
+  public boolean isBlocked() {
+    return blocked;
   }
 
   @Override

--- a/common/src/main/java/io/atomix/catalyst/util/concurrent/ThreadContext.java
+++ b/common/src/main/java/io/atomix/catalyst/util/concurrent/ThreadContext.java
@@ -65,6 +65,15 @@ public interface ThreadContext extends AutoCloseable {
   }
 
   /**
+   * Returns a boolean indicating whether the current thread is in this context.
+   *
+   * @return Indicates whether the current thread is in this context.
+   */
+  default boolean isCurrentContext() {
+    return currentContext() == this;
+  }
+
+  /**
    * Checks that the current thread is the correct context thread.
    */
   default void checkThread() {
@@ -91,6 +100,23 @@ public interface ThreadContext extends AutoCloseable {
    * @return The underlying executor.
    */
   Executor executor();
+
+  /**
+   * Returns a boolean indicating whether the context state is blocked.
+   *
+   * @return Indicates whether the context state is blocked.
+   */
+  boolean isBlocked();
+
+  /**
+   * Sets the context state to blocked.
+   */
+  void block();
+
+  /**
+   * Sets the context state to unblocked.
+   */
+  void unblock();
 
   /**
    * Executes a callback on the context.

--- a/common/src/main/java/io/atomix/catalyst/util/concurrent/ThreadPoolContext.java
+++ b/common/src/main/java/io/atomix/catalyst/util/concurrent/ThreadPoolContext.java
@@ -17,7 +17,6 @@ package io.atomix.catalyst.util.concurrent;
 
 import io.atomix.catalyst.serializer.Serializer;
 import io.atomix.catalyst.util.Assert;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +42,7 @@ public class ThreadPoolContext implements ThreadContext {
   private final Serializer serializer;
   private final Runnable runner;
   private final LinkedList<Runnable> tasks = new LinkedList<>();
+  private volatile boolean blocked;
   private boolean running;
   private final Executor executor = new Executor() {
     @Override
@@ -99,6 +99,21 @@ public class ThreadPoolContext implements ThreadContext {
   @Override
   public Serializer serializer() {
     return serializer;
+  }
+
+  @Override
+  public boolean isBlocked() {
+    return blocked;
+  }
+
+  @Override
+  public void block() {
+    blocked = true;
+  }
+
+  @Override
+  public void unblock() {
+    blocked = false;
   }
 
   @Override


### PR DESCRIPTION
This PR adds support for detecting threads that are blocked by `CompletableFuture.get()` or `CompletableFuture.join()` calls by adding a `BlockingFuture` and flags to `ThreadContext`. When `get()` or `join()` is called on a future within the context thread, the context is flagged as blocked. This prevents deadlock for events that need to use the same thread, allowing them to be completed on a different thread.
