### PR TITLE
Ensure primitive and JDK serializers are always registered

### DIFF
--- a/serializer/src/main/java/io/atomix/catalyst/serializer/SerializableTypeResolver.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/SerializableTypeResolver.java
@@ -18,7 +18,7 @@ package io.atomix.catalyst.serializer;
 /**
  * The serializer type resolver is responsible for locating serializable types and their serializers.
  * <p>
- * Users can implement custom type resolvers to automatically register serializers. See {@link ServiceLoaderTypeResolver}
+ * Users can implement custom type resolvers to automatically register serializers. See {@link JdkTypeResolver}
  * for an example implementation.
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/Serializer.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/Serializer.java
@@ -65,8 +65,9 @@ public class Serializer {
    *   }
    * </pre>
    */
+  @SuppressWarnings("unchecked")
   public Serializer() {
-    this(new UnpooledHeapAllocator(), new PrimitiveTypeResolver(), new JdkTypeResolver());
+    this(new UnpooledHeapAllocator(), Collections.EMPTY_LIST);
   }
 
   /**
@@ -87,8 +88,9 @@ public class Serializer {
    *
    * @param allocator The serializer buffer allocator.
    */
+  @SuppressWarnings("unchecked")
   public Serializer(BufferAllocator allocator) {
-    this(allocator, new PrimitiveTypeResolver(), new JdkTypeResolver());
+    this(allocator, Collections.EMPTY_LIST);
   }
 
   /**

--- a/serializer/src/main/java/io/atomix/catalyst/serializer/SerializerRegistry.java
+++ b/serializer/src/main/java/io/atomix/catalyst/serializer/SerializerRegistry.java
@@ -44,6 +44,8 @@ public class SerializerRegistry {
   }
 
   public SerializerRegistry(Collection<SerializableTypeResolver> resolvers) {
+    resolve(new PrimitiveTypeResolver());
+    resolve(new JdkTypeResolver());
     resolve(resolvers);
   }
 


### PR DESCRIPTION
This PR fixes a bug when constructing a `Serializer` from `Properties` wherein `PrimitiveTypeResolver` and `JdkTypeResolver` are not added to the `SerializerRegistry`.
