### PR TITLE
Provide private lock object to NettyServer

### DIFF
--- a/netty/src/main/java/io/atomix/catalyst/transport/netty/NettyServer.java
+++ b/netty/src/main/java/io/atomix/catalyst/transport/netty/NettyServer.java
@@ -56,6 +56,7 @@ public class NettyServer implements Server {
   private final Map<Channel, NettyConnection> connections = new ConcurrentHashMap<>();
   private ServerHandler handler;
   private ChannelGroup channelGroup;
+  private final Object listenLock = new Object();
   private volatile boolean listening;
   private CompletableFuture<Void> listenFuture;
 
@@ -71,7 +72,7 @@ public class NettyServer implements Server {
       return CompletableFuture.completedFuture(null);
 
     ThreadContext context = ThreadContext.currentContextOrThrow();
-    synchronized (this) {
+    synchronized (listenLock) {
       if (listenFuture == null) {
         listenFuture = new CompletableFuture<>();
         listen(address, listener, context);


### PR DESCRIPTION
Synchronizing on the `this` pointer usually is an implementation leak.
Since there is no external collaboration that requires coordination on
specific instances of `NettyServer`, a private lock object has been
provided to make listening by the `NettyServer` immune to external
synchronization.
