### PR TITLE
Fixes #58, unit tests fail on windows.

### DIFF
--- a/buffer/src/main/java/io/atomix/catalyst/buffer/FileBytes.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/FileBytes.java
@@ -639,6 +639,7 @@ public class FileBytes extends AbstractBytes {
    */
   public void delete() {
     try {
+      close();
       Files.delete(file.toPath());
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/buffer/src/main/java/io/atomix/catalyst/buffer/MappedBytes.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/MappedBytes.java
@@ -112,11 +112,17 @@ public class MappedBytes extends NativeBytes {
     return this;
   }
 
+  @Override
+  public void close() {
+    ((MappedMemory) memory).close();
+  }
+  
   /**
    * Deletes the underlying file.
    */
   public void delete() {
     try {
+      close();
       Files.delete(file.toPath());
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/buffer/src/main/java/io/atomix/catalyst/buffer/util/MappedMemory.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/util/MappedMemory.java
@@ -84,4 +84,9 @@ public class MappedMemory extends NativeMemory {
     ((MappedMemoryAllocator) allocator).release();
   }
 
+  public void close() {
+    free();
+    ((MappedMemoryAllocator) allocator).close();
+  }
+  
 }

--- a/buffer/src/main/java/io/atomix/catalyst/buffer/util/MappedMemoryAllocator.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/util/MappedMemoryAllocator.java
@@ -107,16 +107,20 @@ public class MappedMemoryAllocator implements MemoryAllocator<MappedMemory> {
     return newMemory;
   }
 
+  public void close() {
+    try {
+      file.close();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+  
   /**
    * Releases a reference from the allocator.
    */
   void release() {
     if (referenceCount.decrementAndGet() == 0) {
-      try {
-        file.close();
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
+      close();
     }
   }
 


### PR DESCRIPTION
Fixes #58 These changes close the RandomAccessFiles that underlie the buffers before they get deleted.