### PR TITLE
Ensure byte order in HeapMemory is attentive to native orderq

### DIFF
--- a/buffer/src/main/java/io/atomix/catalyst/buffer/NativeBytes.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/NativeBytes.java
@@ -45,7 +45,7 @@ public abstract class NativeBytes extends AbstractBytes {
 
   @Override
   public Bytes resize(long newSize) {
-    this.memory = memory.allocator().reallocate(memory, newSize);
+    this.memory = (NativeMemory) memory.allocator().reallocate(memory, newSize);
     return this;
   }
 

--- a/buffer/src/main/java/io/atomix/catalyst/buffer/util/HeapMemory.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/util/HeapMemory.java
@@ -134,32 +134,56 @@ public class HeapMemory implements Memory {
 
   @Override
   public char getChar(long offset) {
-    return NativeMemory.UNSAFE.getChar(array, address(offset));
+    if (NativeMemory.BIG_ENDIAN) {
+      return NativeMemory.UNSAFE.getChar(array, address(offset));
+    } else {
+      return Character.reverseBytes(NativeMemory.UNSAFE.getChar(array, address(offset)));
+    }
   }
 
   @Override
   public short getShort(long offset) {
-    return NativeMemory.UNSAFE.getShort(array, address(offset));
+    if (NativeMemory.BIG_ENDIAN) {
+      return NativeMemory.UNSAFE.getShort(array, address(offset));
+    } else {
+      return Short.reverseBytes(NativeMemory.UNSAFE.getShort(array, address(offset)));
+    }
   }
 
   @Override
   public int getInt(long offset) {
-    return NativeMemory.UNSAFE.getInt(array, address(offset));
+    if (NativeMemory.BIG_ENDIAN) {
+      return NativeMemory.UNSAFE.getInt(array, address(offset));
+    } else {
+      return Integer.reverseBytes(NativeMemory.UNSAFE.getInt(array, address(offset)));
+    }
   }
 
   @Override
   public long getLong(long offset) {
-    return NativeMemory.UNSAFE.getLong(array, address(offset));
+    if (NativeMemory.BIG_ENDIAN) {
+      return NativeMemory.UNSAFE.getLong(array, address(offset));
+    } else {
+      return Long.reverseBytes(NativeMemory.UNSAFE.getLong(array, address(offset)));
+    }
   }
 
   @Override
   public float getFloat(long offset) {
-    return NativeMemory.UNSAFE.getFloat(array, address(offset));
+    if (NativeMemory.BIG_ENDIAN) {
+      return NativeMemory.UNSAFE.getFloat(array, address(offset));
+    } else {
+      return Float.intBitsToFloat(NativeMemory.UNSAFE.getInt(array, address(offset)));
+    }
   }
 
   @Override
   public double getDouble(long offset) {
-    return NativeMemory.UNSAFE.getDouble(array, address(offset));
+    if (NativeMemory.BIG_ENDIAN) {
+      return NativeMemory.UNSAFE.getDouble(array, address(offset));
+    } else {
+      return Double.longBitsToDouble(NativeMemory.UNSAFE.getLong(array, address(offset)));
+    }
   }
 
   @Override
@@ -169,32 +193,56 @@ public class HeapMemory implements Memory {
 
   @Override
   public void putChar(long offset, char c) {
-    NativeMemory.UNSAFE.putChar(array, address(offset), c);
+    if (NativeMemory.BIG_ENDIAN) {
+      NativeMemory.UNSAFE.putChar(array, address(offset), c);
+    } else {
+      NativeMemory.UNSAFE.putChar(array, address(offset), Character.reverseBytes(c));
+    }
   }
 
   @Override
   public void putShort(long offset, short s) {
-    NativeMemory.UNSAFE.putShort(array, address(offset), s);
+    if (NativeMemory.BIG_ENDIAN) {
+      NativeMemory.UNSAFE.putShort(array, address(offset), s);
+    } else {
+      NativeMemory.UNSAFE.putShort(array, address(offset), Short.reverseBytes(s));
+    }
   }
 
   @Override
   public void putInt(long offset, int i) {
-    NativeMemory.UNSAFE.putInt(array, address(offset), i);
+    if (NativeMemory.BIG_ENDIAN) {
+      NativeMemory.UNSAFE.putInt(array, address(offset), i);
+    } else {
+      NativeMemory.UNSAFE.putInt(array, address(offset), Integer.reverseBytes(i));
+    }
   }
 
   @Override
   public void putLong(long offset, long l) {
-    NativeMemory.UNSAFE.putLong(array, address(offset), l);
+    if (NativeMemory.BIG_ENDIAN) {
+      NativeMemory.UNSAFE.putLong(array, address(offset), l);
+    } else {
+      NativeMemory.UNSAFE.putLong(array, address(offset), Long.reverseBytes(l));
+    }
   }
 
   @Override
   public void putFloat(long offset, float f) {
-    NativeMemory.UNSAFE.putFloat(array, address(offset), f);
+    if (NativeMemory.BIG_ENDIAN) {
+      NativeMemory.UNSAFE.putFloat(array, address(offset), f);
+    } else {
+      NativeMemory.UNSAFE.putInt(array, address(offset), Float.floatToIntBits(f));
+    }
   }
 
   @Override
   public void putDouble(long offset, double d) {
-    NativeMemory.UNSAFE.putDouble(array, address(offset), d);
+    if (NativeMemory.BIG_ENDIAN) {
+      NativeMemory.UNSAFE.putDouble(array, address(offset), d);
+    } else {
+      NativeMemory.UNSAFE.putLong(array, address(offset), Double.doubleToLongBits(d));
+    }
   }
 
   @Override

--- a/buffer/src/main/java/io/atomix/catalyst/buffer/util/NativeMemory.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/util/NativeMemory.java
@@ -30,7 +30,7 @@ import java.nio.ByteOrder;
 public class NativeMemory implements Memory {
   static final Unsafe UNSAFE;
   private static final boolean UNALIGNED;
-  private static final boolean BIG_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
+  static final boolean BIG_ENDIAN = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN;
 
   /**
    * Allocates native memory via {@link DirectMemoryAllocator}.
@@ -78,7 +78,7 @@ public class NativeMemory implements Memory {
 
   @Override
   @SuppressWarnings("unchecked")
-  public MemoryAllocator<NativeMemory> allocator() {
+  public MemoryAllocator allocator() {
     return allocator;
   }
 

--- a/buffer/src/test/java/io/atomix/catalyst/buffer/BufferTest.java
+++ b/buffer/src/test/java/io/atomix/catalyst/buffer/BufferTest.java
@@ -15,13 +15,15 @@
  */
 package io.atomix.catalyst.buffer;
 
-import org.testng.annotations.Test;
-
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteOrder;
 
-import static org.testng.Assert.*;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Base buffer test.

--- a/buffer/src/test/java/io/atomix/catalyst/buffer/FileBufferTest.java
+++ b/buffer/src/test/java/io/atomix/catalyst/buffer/FileBufferTest.java
@@ -18,6 +18,8 @@ package io.atomix.catalyst.buffer;
 import org.testng.annotations.AfterTest;
 
 import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.file.Files;
 
 import static org.testng.Assert.*;
@@ -52,6 +54,16 @@ public class FileBufferTest extends BufferTest {
       buffer.writeLong(10).writeLong(11).flip();
       assertEquals(buffer.readLong(), 10);
       assertEquals(buffer.readLong(), 11);
+      buffer.rewind();
+      byte[] bytes = new byte[(int) buffer.remaining()];
+      buffer.read(bytes);
+      ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+      assertEquals(byteBuffer.getLong(), 10);
+      assertEquals(byteBuffer.getLong(), 11);
+      HeapBuffer heapBuffer = HeapBuffer.wrap(bytes);
+      ByteOrder order = heapBuffer.order();
+      assertEquals(heapBuffer.readLong(), 10);
+      assertEquals(heapBuffer.readLong(), 11);
     }
     try (FileBuffer buffer = FileBuffer.allocate(file, 16)) {
       assertEquals(buffer.readLong(), 10);

--- a/buffer/src/test/java/io/atomix/catalyst/buffer/HeapBufferTest.java
+++ b/buffer/src/test/java/io/atomix/catalyst/buffer/HeapBufferTest.java
@@ -15,11 +15,18 @@
  */
 package io.atomix.catalyst.buffer;
 
+import java.nio.ByteBuffer;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
 /**
  * Heap buffer test.
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
+@Test
 public class HeapBufferTest extends BufferTest {
 
   @Override
@@ -30,6 +37,46 @@ public class HeapBufferTest extends BufferTest {
   @Override
   protected Buffer createBuffer(long capacity, long maxCapacity) {
     return HeapBuffer.allocate(capacity, maxCapacity);
+  }
+
+  public void testByteBufferToHeapBuffer() {
+    ByteBuffer byteBuffer = ByteBuffer.allocate(8);
+    byteBuffer.putLong(10);
+    byteBuffer.flip();
+
+    DirectBuffer directBuffer = DirectBuffer.allocate(8);
+    directBuffer.write(byteBuffer.array());
+    directBuffer.flip();
+    assertEquals(directBuffer.readLong(), byteBuffer.getLong());
+
+    byteBuffer.rewind();
+    HeapBuffer heapBuffer = HeapBuffer.wrap(byteBuffer.array());
+    assertEquals(heapBuffer.readLong(), byteBuffer.getLong());
+  }
+
+  public void testDirectToHeapBuffer() {
+    DirectBuffer directBuffer = DirectBuffer.allocate(8);
+    directBuffer.writeLong(10);
+    directBuffer.flip();
+
+    byte[] bytes = new byte[8];
+    directBuffer.read(bytes);
+    directBuffer.rewind();
+
+    HeapBuffer heapBuffer = HeapBuffer.wrap(bytes);
+    assertEquals(directBuffer.readLong(), heapBuffer.readLong());
+  }
+
+  public void testHeapToDirectBuffer() {
+    HeapBuffer heapBuffer = HeapBuffer.allocate(8);
+    heapBuffer.writeLong(10);
+    heapBuffer.flip();
+
+    DirectBuffer directBuffer = DirectBuffer.allocate(8);
+    directBuffer.write(heapBuffer.array());
+    directBuffer.flip();
+
+    assertEquals(directBuffer.readLong(), heapBuffer.readLong());
   }
 
 }


### PR DESCRIPTION
Fixes improper byte ordering for heap memory that uses `Unsafe` for memory access