### PR TITLE
Optimize FileBytes read/write for byte arrays

### DIFF
--- a/buffer/src/main/java/io/atomix/catalyst/buffer/Buffer.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/Buffer.java
@@ -60,6 +60,15 @@ import java.nio.ByteOrder;
 public interface Buffer extends BytesInput<Buffer>, BufferInput<Buffer>, BytesOutput<Buffer>, BufferOutput<Buffer>, ReferenceCounted<Buffer> {
 
   /**
+   * Returns whether the buffer has an array.
+   *
+   * @return Whether the buffer has an underlying array.
+   */
+  default boolean hasArray() {
+    return false;
+  }
+
+  /**
    * Returns the underlying byte array.
    *
    * @return the underlying byte array

--- a/buffer/src/main/java/io/atomix/catalyst/buffer/BufferInput.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/BufferInput.java
@@ -92,6 +92,18 @@ public interface BufferInput<T extends BufferInput<?>> extends AutoCloseable {
   T read(Buffer buffer);
 
   /**
+   * Reads a byte array.
+   *
+   * @param length The byte array length
+   * @return The read byte array.
+   */
+  default byte[] readBytes(int length) {
+    byte[] bytes = new byte[length];
+    read(bytes);
+    return bytes;
+  }
+
+  /**
    * Reads a byte from the buffer at the current position.
    *
    * @return The read byte.

--- a/buffer/src/main/java/io/atomix/catalyst/buffer/BufferOutput.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/BufferOutput.java
@@ -72,6 +72,18 @@ public interface BufferOutput<T extends BufferOutput<?>> extends AutoCloseable {
   T write(Buffer buffer);
 
   /**
+   * Writes a byte array.
+   *
+   * @param bytes The byte array to write.
+   * @return The written buffer.
+   */
+  @SuppressWarnings("unchecked")
+  default T writeBytes(byte[] bytes) {
+    write(bytes);
+    return (T) this;
+  }
+
+  /**
    * Writes a byte to the buffer.
    *
    * @param b The byte to write.

--- a/buffer/src/main/java/io/atomix/catalyst/buffer/Bytes.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/Bytes.java
@@ -34,6 +34,15 @@ public interface Bytes extends BytesInput<Bytes>, BytesOutput<Bytes>, AutoClosea
   int DOUBLE = 8;
 
   /**
+   * Returns whether the bytes has an array.
+   *
+   * @return Whether the bytes has an underlying array.
+   */
+  default boolean hasArray() {
+    return false;
+  }
+
+  /**
    * Returns the underlying byte array.
    *
    * @return the underlying byte array

--- a/buffer/src/main/java/io/atomix/catalyst/buffer/HeapBuffer.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/HeapBuffer.java
@@ -101,4 +101,8 @@ public class HeapBuffer extends ByteBufferBuffer {
     super(bytes, offset, initialCapacity, maxCapacity, null);
   }
 
+  @Override
+  public boolean hasArray() {
+    return true;
+  }
 }

--- a/buffer/src/main/java/io/atomix/catalyst/buffer/HeapBytes.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/HeapBytes.java
@@ -45,4 +45,8 @@ public class HeapBytes extends ByteBufferBytes {
     return ByteBuffer.allocate((int) size);
   }
 
+  @Override
+  public boolean hasArray() {
+    return true;
+  }
 }

--- a/buffer/src/main/java/io/atomix/catalyst/buffer/UnsafeHeapBuffer.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/UnsafeHeapBuffer.java
@@ -122,6 +122,11 @@ public class UnsafeHeapBuffer extends AbstractBuffer {
   }
 
   @Override
+  public boolean hasArray() {
+    return true;
+  }
+
+  @Override
   public byte[] array() {
     return bytes.memory.array();
   }

--- a/buffer/src/main/java/io/atomix/catalyst/buffer/UnsafeHeapBytes.java
+++ b/buffer/src/main/java/io/atomix/catalyst/buffer/UnsafeHeapBytes.java
@@ -71,6 +71,11 @@ public class UnsafeHeapBytes extends AbstractBytes {
   }
 
   @Override
+  public boolean hasArray() {
+    return true;
+  }
+
+  @Override
   public byte[] array() {
     return memory.array();
   }


### PR DESCRIPTION
This PR fixes a performance defect in `FileBytes` when reading and writing byte arrays. The current implementation writes individual bytes, which can significantly affect performance in certain environments. This implementation simply delegates writing of individual bytes to the underlying `RandomAccessFile`.